### PR TITLE
[#5] Fix broken 'PAGES' template variable

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -28,7 +28,7 @@
                 {% if not PAGES_SORT_ATTRIBUTE -%}
                     {% set PAGES_SORT_ATTRIBUTE = 'title' %}
                 {% endif %}
-                {% for pg in PAGES | sort(attribute=PAGES_SORT_ATTRIBUTE) %}
+                {% for pg in pages | sort(attribute=PAGES_SORT_ATTRIBUTE) %}
                     {% if 'http://' in pg.url -%}
                         <li><a href="{{ pg.url }}">{{ pg.title }}</a></li>
                     {% else %}    


### PR DESCRIPTION
Pages were not displayed in the menue because the template variable used
``PAGES``) should not be in all-caps but ``pages`` instead.
This commit fixes this.

Closes: #5